### PR TITLE
Add improved async wrap handler

### DIFF
--- a/.changeset/nervous-olives-fetch.md
+++ b/.changeset/nervous-olives-fetch.md
@@ -1,0 +1,5 @@
+---
+"@unruly-software/result": major
+---
+
+Improve `AsyncResult.wrap()` by allowing timeouts and modifications to be chained to the returned AsyncResult

--- a/src/AsyncResult.ts
+++ b/src/AsyncResult.ts
@@ -1,6 +1,7 @@
 import { Result, Fail, Success } from './Result'
 
 import { ResultTimeoutError } from './ResultTimeout'
+import { wrapAsyncFunction } from './WrappedFunction'
 
 type UnwrappedAsyncResult<T, E extends Error = Error> = AsyncResult<
   Awaited<T>,
@@ -21,15 +22,7 @@ export class AsyncResult<T, F extends Error = Error>
    * const maybeUser = await safeGetUser(userId) // AsyncResult<User, Error>
    * ```
    */
-  static wrap<FN extends (...args: any[]) => any>(fn: FN) {
-    return (
-      ...args: Parameters<FN>
-    ): FN extends (...args: any[]) => Promise<infer RT>
-      ? AsyncResult<RT>
-      : never => {
-      return AsyncResult.invoke(fn as any, ...(args as any[])) as any
-    }
-  }
+  static wrap = wrapAsyncFunction
 
   /**
    * Invoke a function that returns a promise and wrap the result in an

--- a/src/WrappedFunction.ts
+++ b/src/WrappedFunction.ts
@@ -1,0 +1,132 @@
+import { AsyncResult } from './AsyncResult'
+import { ResultTimeoutError } from './ResultTimeout'
+
+interface AsyncWrappedFunction<P extends any[], RT, F extends Error = Error> {
+  (...args: P): AsyncResult<RT, F>
+
+  withTimeout<E extends Error = ResultTimeoutError>(
+    ms: number,
+    error?: E,
+  ): AsyncWrappedFunction<P, RT, F | E>
+
+  tap(
+    mapSuccess: (success: RT) => unknown,
+    mapError?: (error: F) => unknown,
+  ): AsyncWrappedFunction<P, RT, F>
+
+  tapAsync(
+    mapSuccess: (success: RT) => Promise<unknown>,
+    mapError?: (error: F) => Promise<unknown>,
+  ): AsyncWrappedFunction<P, RT, F>
+
+  map<X, Y extends Error = F>(
+    mapSuccess: (success: RT) => X,
+    mapError?: (error: F) => Y,
+  ): AsyncWrappedFunction<P, X, Y>
+
+  mapAsync<X, Y extends Error = F>(
+    mapSuccess: (success: RT) => Promise<X>,
+    mapError?: (error: F) => Promise<Y>,
+  ): AsyncWrappedFunction<P, X, Y>
+
+  flatMap<X, Y extends Error = F>(
+    mapSuccess: (success: RT) => AsyncResult<X, Y>,
+    mapError?: (error: F) => AsyncResult<X, Y>,
+  ): AsyncWrappedFunction<P, X, Y>
+
+  flatMapAsync<X, Y extends Error = F>(
+    mapSuccess: (success: RT) => AsyncResult<X, Y>,
+    mapError?: (error: F) => AsyncResult<X, Y>,
+  ): AsyncWrappedFunction<P, X, Y>
+
+  mapFailure<X extends Error = F>(
+    mapFailure: (failed: F) => X,
+  ): AsyncWrappedFunction<P, RT, X>
+}
+
+export function wrapAsyncFunction<
+  FN extends (...args: any[]) => any,
+  F extends Error = Error,
+>(fn: FN): AsyncWrappedFunction<Parameters<FN>, Awaited<ReturnType<FN>>, F> {
+  const wrapped: AsyncWrappedFunction<
+    Parameters<FN>,
+    Awaited<ReturnType<FN>>,
+    F
+  > = ((...args) => {
+    return AsyncResult.invoke(fn as any, ...(args as any[])) as any
+  }) as any
+
+  wrapped.withTimeout = (ms, error) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .withTimeout(ms, error)
+        .get()
+    })
+  }
+
+  wrapped.map = (mapSuccess, mapError) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .map(mapSuccess, mapError)
+        .get()
+    })
+  }
+
+  wrapped.mapAsync = (mapSuccess, mapError) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .mapAsync(mapSuccess, mapError)
+        .get()
+    })
+  }
+
+  wrapped.tap = (mapSuccess, mapError) =>
+    wrapped.map(
+      (v) => {
+        mapSuccess(v)
+        return v
+      },
+      (v) => {
+        mapError?.(v)
+        return v
+      },
+    )
+
+  wrapped.tapAsync = (mapSuccess, mapError) =>
+    wrapped.mapAsync(
+      async (v) => {
+        await mapSuccess(v)
+        return v
+      },
+      async (v) => {
+        await mapError?.(v)
+        return v
+      },
+    ) as any
+
+  wrapped.flatMap = ((mapSuccess, mapError) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .flatMap(mapSuccess, mapError)
+        .get()
+    })
+  }) as any
+
+  wrapped.flatMapAsync = ((mapSuccess, mapError) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .flatMapAsync(mapSuccess, mapError)
+        .get()
+    })
+  }) as any
+
+  wrapped.mapFailure = (mapFailure) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .mapFailure(mapFailure)
+        .get()
+    })
+  }
+
+  return wrapped
+}


### PR DESCRIPTION
Allows wrapped async functions to have modifications applied to their return type with the same chainable pattern that the AsyncResult has.