### PR TITLE
Map either interface

### DIFF
--- a/.changeset/healthy-walls-worry.md
+++ b/.changeset/healthy-walls-worry.md
@@ -1,0 +1,5 @@
+---
+"@unruly-software/result": patch
+---
+
+Adds the `mapEither`, `mapEitherAsync`, `tapEither`, and `tapEitherAsync` methods which simplify logging and error recovery when the state of a result doesn't matter.

--- a/src/AsyncResult.ts
+++ b/src/AsyncResult.ts
@@ -250,4 +250,35 @@ export class AsyncResult<T, F extends Error = Error>
   ): AsyncResult<T, X> {
     return new AsyncResult(this.then((result) => result.mapFailure(mapFailure)))
   }
+
+  /**
+   * Apply a function to either the success or failure value and in the process
+   * recover from a failure.
+   */
+  mapEither<X>(map: (value: T | F) => X): AsyncResult<X, F> {
+    return new AsyncResult(this.then((result) => result.mapEither(map)))
+  }
+
+  /**
+   * Apply a function to either the success or failure value asynchronously
+   * and in the process recover from a failure.
+   */
+  mapEitherAsync<X>(map: (value: T | F) => Promise<X>): AsyncResult<X> {
+    return new AsyncResult(this.then((result) => result.mapEitherAsync(map)))
+  }
+
+  /**
+   * Apply a function to either the success or failure value  without modifying its value
+   **/
+  tapEither(tap: (value: T | F) => unknown): AsyncResult<T, F> {
+    return this.tap(tap, tap)
+  }
+
+  /**
+   * Apply a function to either the success or failure value asynchronously
+   * without modifying its value
+   **/
+  tapEitherAsync(tap: (value: T | F) => Promise<unknown>): AsyncResult<T, F> {
+    return this.tapAsync(tap, tap)
+  }
 }

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -285,6 +285,39 @@ export abstract class Result<T, F extends Error = Error> {
   }
 
   /**
+   * Apply a function to either the success or failure value and in the process
+   * recover from a failure.
+   */
+  mapEither<X>(map: (value: T | F) => X): Result<X, F> {
+    const mapFunc = this.isFail() ? this.recover : this.map
+    return mapFunc.call(this, map)
+  }
+
+  /**
+   * Apply a function to either the success or failure value asynchronously
+   * and in the process recover from a failure.
+   */
+  mapEitherAsync<X>(map: (value: T | F) => Promise<X>): AsyncResult<X> {
+    const mapFunc = this.isFail() ? this.recoverAsync : this.mapAsync
+    return mapFunc.call(this, map)
+  }
+
+  /**
+   * Apply a function to either the success or failure value  without modifying its value
+   **/
+  tapEither(tap: (value: T | F) => unknown): Result<T, F> {
+    return this.tap(tap, tap)
+  }
+
+  /**
+   * Apply a function to either the success or failure value asynchronously
+   * without modifying its value
+   **/
+  tapEitherAsync(tap: (value: T | F) => Promise<unknown>): AsyncResult<T, F> {
+    return this.tapAsync(tap, tap)
+  }
+
+  /**
    * Attempt to recover from a failure by mapping the error value to a success
    * value. If the result is a success, the mapping function is ignored.
    *

--- a/src/WrappedFunction.ts
+++ b/src/WrappedFunction.ts
@@ -42,6 +42,18 @@ interface AsyncWrappedFunction<P extends any[], RT, F extends Error = Error> {
   mapFailure<X extends Error = F>(
     mapFailure: (failed: F) => X,
   ): AsyncWrappedFunction<P, RT, X>
+
+  mapEither<X>(map: (value: RT | F) => X): AsyncWrappedFunction<P, X, F>
+
+  mapEitherAsync<X>(
+    map: (value: RT | F) => Promise<X>,
+  ): AsyncWrappedFunction<P, X, F>
+
+  tapEither(tap: (value: RT | F) => unknown): AsyncWrappedFunction<P, RT, F>
+
+  tapEitherAsync(
+    tap: (value: RT | F) => Promise<unknown>,
+  ): AsyncWrappedFunction<P, RT, F>
 }
 
 export function wrapAsyncFunction<
@@ -124,6 +136,38 @@ export function wrapAsyncFunction<
     return wrapAsyncFunction(async (...args: Parameters<FN>) => {
       return wrapped(...args)
         .mapFailure(mapFailure)
+        .get()
+    })
+  }
+
+  wrapped.mapEither = (map) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .mapEither(map)
+        .get()
+    })
+  }
+
+  wrapped.mapEitherAsync = (map) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .mapEitherAsync(map)
+        .get()
+    })
+  }
+
+  wrapped.tapEither = (tap) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .tapEither(tap)
+        .get()
+    })
+  }
+
+  wrapped.tapEitherAsync = (tap) => {
+    return wrapAsyncFunction(async (...args: Parameters<FN>) => {
+      return wrapped(...args)
+        .tapEitherAsync(tap)
         .get()
     })
   }

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -24,6 +24,7 @@ const testAll = <T, Y>(name: string, test: TestCase<T, Y>) => {
     it('it should work given Result', async () => {
       await test.assert(await test.transform(await test.setup()).getEither())
     })
+
     it('should work given a wrapped async function', async () => {
       const wrapped: any = AsyncResult.wrap(async () => {
         return test.setup().get()
@@ -90,6 +91,42 @@ testAll('flatMap', {
   setup: () => AsyncResult.success(value),
   transform: (result) => result.flatMap(() => Result.success('Other value')),
   assert: (value) => expect(value).toEqual('Other value'),
+})
+
+testAll('mapEither', {
+  setup: () => Result.success(value),
+  transform: (result) => result.mapEither(() => 'Other value'),
+  assert: (value) => expect(value).toEqual('Other value'),
+})
+
+testAll('mapEither(failure)', {
+  setup: () => Result.fail(error),
+  transform: (result) => result.mapEither(() => 'Other value'),
+  assert: (value) => expect(value).toEqual('Other value'),
+})
+
+testAll('tapEither', {
+  setup: () => Result.success(value),
+  transform: (result) => result.tapEither(() => 'Other value'),
+  assert: (passed) => expect(passed).toEqual(value),
+})
+
+testAll('tapEither(failure)', {
+  setup: () => Result.fail(error),
+  transform: (result) => result.tapEither(() => 'Other value'),
+  assert: (passed) => expect(passed).toEqual(error),
+})
+
+testAll('tapEitherAsync', {
+  setup: () => Result.success(value),
+  transform: (result) => result.tapEitherAsync(async () => 'Other value'),
+  assert: (passed) => expect(passed).toEqual(value),
+})
+
+testAll('tapEitherAsync(failure)', {
+  setup: () => Result.fail(error),
+  transform: (result) => result.tapEitherAsync(async () => 'Other value'),
+  assert: (passed) => expect(passed).toEqual(error),
 })
 
 describe('Result', () => {


### PR DESCRIPTION
Adds `mapEither`, `mapEitherAsync`, `tapEither`, and `tapEitherAsync`

These methods simplify recovering errors and logging when the success or failure of a result doesn't matter.